### PR TITLE
Linux: Use `xdg-user-dir` to get the default Downloads folder path

### DIFF
--- a/src/main/java/com/tonikelope/megabasterd/SettingsDialog.java
+++ b/src/main/java/com/tonikelope/megabasterd/SettingsDialog.java
@@ -174,7 +174,7 @@ public class SettingsDialog extends javax.swing.JDialog {
 
             String default_download_dir = DBTools.selectSettingValue("default_down_dir");
 
-            default_download_dir = Paths.get(default_download_dir == null ? MainPanel.MEGABASTERD_HOME_DIR : default_download_dir).toAbsolutePath().normalize().toString();
+            default_download_dir = (default_download_dir == null ? _main_panel.getDefault_download_path() : default_download_dir);
 
             _download_path = default_download_dir;
 


### PR DESCRIPTION
Instead of defaulting the Downloads folder path to `.` (current directory) on Linux, we can instead rely on the `xdg-user-dir` [tool](https://www.freedesktop.org/wiki/Software/xdg-user-dirs/), which should give us a more accurate location for the default Downloads folder.

If the `xdg-user-dir` output does not give us an actual, existing directory, we just fall back to the current directory, like before.