### PR TITLE
Fixed the close operation

### DIFF
--- a/src/main/java/com/tonikelope/megabasterd/MainPanelView.java
+++ b/src/main/java/com/tonikelope/megabasterd/MainPanelView.java
@@ -452,6 +452,8 @@ public final class MainPanelView extends javax.swing.JFrame {
     public MainPanelView(MainPanel main_panel) {
 
         _main_panel = main_panel;
+        
+        setDefaultCloseOperation(EXIT_ON_CLOSE);
 
         MiscTools.GUIRunAndWait(() -> {
 


### PR DESCRIPTION
There's a tiny and almost undetectable bug. When you close the application it's still running in the background without the end user ever noticing which can lead to a waster of the user's machine resources.

The fix was pretty easy to do. The only modification I did to the codebase was going to the contructor of `MainPanelView` and adding this line to the beginning

``` Java
setDefaultCloseOperation(EXIT_ON_CLOSE)
```

With this code the app immediatly closes once the user closes the window avoiding any extra resource consumption