### PR TITLE
bug: don't retry dead links

### DIFF
--- a/src/main/java/com/tonikelope/megabasterd/Transference.java
+++ b/src/main/java/com/tonikelope/megabasterd/Transference.java
@@ -28,7 +28,7 @@ public interface Transference {
     boolean LIMIT_TRANSFERENCE_SPEED_DEFAULT = false;
     int MAX_TRANSFERENCE_SPEED_DEFAULT = 5;
     int MAX_WAIT_WORKERS_SHUTDOWN = 15;
-    Integer[] FATAL_API_ERROR_CODES = {-2, -4, -8, -14, -15, -16, -17, 22, 23, 24};
+    Integer[] FATAL_API_ERROR_CODES = {-2, -4, -8, -9, -14, -15, -16, -17, 22, 23, 24};
     Integer[] FATAL_API_ERROR_CODES_WITH_RETRY = {-4};
 
     void start();


### PR DESCRIPTION
Sorry if the PR looks shabby, this is my first time trying to do it.

My Problem : 

When trying to use MegaBasterd sometimes there are files that do not exist (have 0 bytes)  that give error -9, 
which then results the application requesting it again only to throw an error that continues the loop,
if there are enough of those "Dead files", the download stops entirely

![newpic](https://github.com/user-attachments/assets/e9a7ea7b-2deb-4dd5-b2dd-d85d05b1b0d7)


My solution :
making the error code fatal,
so that the application won't request the dead file again, making the downloads continue 