### PR TITLE
Clipboard monitor readding links fix

### DIFF
--- a/src/main/java/com/tonikelope/megabasterd/LinkGrabberDialog.java
+++ b/src/main/java/com/tonikelope/megabasterd/LinkGrabberDialog.java
@@ -462,7 +462,9 @@ public class LinkGrabberDialog extends javax.swing.JDialog implements ClipboardC
         MiscTools.GUIRun(() -> {
             String current_text = links_textarea.getText();
 
-            links_textarea.append((current_text.length() > 0 ? "\n\n" : "") + extractMegaLinksFromString(extractStringFromClipboardContents(_clipboardspy.getContents())));
+            String extractedMegaLinksFromString = extractMegaLinksFromString(extractStringFromClipboardContents(_clipboardspy.getContents()));
+            if(! current_text.contains(extractedMegaLinksFromString))
+                links_textarea.append((current_text.length() > 0 ? "\n\n" : "") + extractedMegaLinksFromString);
         });
     }
 

--- a/src/main/java/com/tonikelope/megabasterd/LinkGrabberDialog.java
+++ b/src/main/java/com/tonikelope/megabasterd/LinkGrabberDialog.java
@@ -460,11 +460,18 @@ public class LinkGrabberDialog extends javax.swing.JDialog implements ClipboardC
     public void notifyClipboardChange() {
 
         MiscTools.GUIRun(() -> {
-            String current_text = links_textarea.getText();
+            String stringFromClipboard = extractStringFromClipboardContents(_clipboardspy.getContents());
+            String extractedMegaLinks = extractMegaLinksFromString(stringFromClipboard);
+            if (!extractedMegaLinks.isEmpty()){
+                Set<String> link_set = new LinkedHashSet<>();
+                final String REGEX_ONE_OR_MORE_NEWLINE = "\\n+";
+                Arrays.stream(links_textarea.getText().split(REGEX_ONE_OR_MORE_NEWLINE))
+                                .filter(s->!s.isEmpty())
+                                        .forEach(link_set::add);
+                Collections.addAll(link_set, extractedMegaLinks.split(REGEX_ONE_OR_MORE_NEWLINE));
 
-            String extractedMegaLinksFromString = extractMegaLinksFromString(extractStringFromClipboardContents(_clipboardspy.getContents()));
-            if(! current_text.contains(extractedMegaLinksFromString))
-                links_textarea.append((current_text.length() > 0 ? "\n\n" : "") + extractedMegaLinksFromString);
+                links_textarea.setText(String.join("\n\n", link_set));
+            }
         });
     }
 


### PR DESCRIPTION
modified LinkGrabberDialog.notifyClipboardChange() to prevent addition of duplicate links
Fixes Issue: [Issue 715](https://github.com/tonikelope/megabasterd/issues/715)