### PR TITLE
Add setting to always reload MEGA folders

### DIFF
--- a/src/main/java/com/tonikelope/megabasterd/MegaAPI.java
+++ b/src/main/java/com/tonikelope/megabasterd/MegaAPI.java
@@ -1513,7 +1513,15 @@ public class MegaAPI implements Serializable {
 
     public static final long FOLDER_CACHE_MAX_AGE_MS = 24L * 60L * 60L * 1000L;
 
+    private static boolean isAlwaysReloadMegaFoldersEnabled() {
+        return "yes".equals(DBTools.selectSettingValue("always_reload_mega_folders"));
+    }
+
     public boolean existsCachedFolderNodes(String folder_id) {
+
+        if (isAlwaysReloadMegaFoldersEnabled()) {
+            return false;
+        }
 
         java.nio.file.Path p = Paths.get(_folderCachePath(folder_id));
 
@@ -1577,7 +1585,7 @@ public class MegaAPI implements Serializable {
         HashMap<String, Object> folder_nodes = null;
         String res = null;
 
-        if (cache) {
+        if (cache && !isAlwaysReloadMegaFoldersEnabled()) {
             res = getCachedFolderNodes(folder_id);
         }
 
@@ -1689,7 +1697,7 @@ public class MegaAPI implements Serializable {
         HashMap<String, Object> folder_nodes = null;
         String res = null;
 
-        if (cache) {
+        if (cache && !isAlwaysReloadMegaFoldersEnabled()) {
             res = getCachedFolderNodes(folder_id);
         }
 

--- a/src/main/java/com/tonikelope/megabasterd/SettingsDialog.form
+++ b/src/main/java/com/tonikelope/megabasterd/SettingsDialog.form
@@ -155,6 +155,7 @@
                                       <Component id="verify_file_down_checkbox" min="-2" max="-2" attributes="0"/>
                                       <Component id="limit_download_speed_checkbox" alignment="0" min="-2" max="-2" attributes="0"/>
                                       <Component id="clipboardspy_checkbox" alignment="0" min="-2" max="-2" attributes="0"/>
+                                      <Component id="always_reload_mega_folders_checkbox" alignment="0" min="-2" max="-2" attributes="0"/>
                                       <Group type="102" attributes="0">
                                           <EmptySpace min="21" pref="21" max="-2" attributes="0"/>
                                           <Group type="103" groupAlignment="0" attributes="0">
@@ -218,6 +219,8 @@
                           <Component id="rec_download_slots_label" min="-2" max="-2" attributes="0"/>
                           <EmptySpace type="unrelated" max="-2" attributes="0"/>
                           <Component id="clipboardspy_checkbox" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace max="-2" attributes="0"/>
+                          <Component id="always_reload_mega_folders_checkbox" min="-2" max="-2" attributes="0"/>
                           <EmptySpace min="-2" pref="10" max="-2" attributes="0"/>
                           <Component id="limit_download_speed_checkbox" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="-2" attributes="0"/>
@@ -478,6 +481,14 @@
                       <Font name="Dialog" size="18" style="1"/>
                     </Property>
                     <Property name="text" type="java.lang.String" value="Monitor clipboard looking for new links"/>
+                  </Properties>
+                </Component>
+                <Component class="javax.swing.JCheckBox" name="always_reload_mega_folders_checkbox">
+                  <Properties>
+                    <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
+                      <Font name="Dialog" size="18" style="1"/>
+                    </Property>
+                    <Property name="text" type="java.lang.String" value="Always reload MEGA folders instead of using cached folder data"/>
                   </Properties>
                 </Component>
                 <Container class="javax.swing.JPanel" name="smart_proxy_settings">

--- a/src/main/java/com/tonikelope/megabasterd/SettingsDialog.java
+++ b/src/main/java/com/tonikelope/megabasterd/SettingsDialog.java
@@ -267,6 +267,14 @@ public class SettingsDialog extends javax.swing.JDialog {
                 monitor_clipboard = monitor_clipboard_string.equals("yes");
             }
 
+            boolean always_reload_mega_folders = false;
+
+            String always_reload_mega_folders_string = DBTools.selectSettingValue("always_reload_mega_folders");
+
+            if (always_reload_mega_folders_string != null) {
+                always_reload_mega_folders = always_reload_mega_folders_string.equals("yes");
+            }
+
             boolean thumbnails = Upload.DEFAULT_THUMBNAILS;
 
             String thumbnails_string = DBTools.selectSettingValue("thumbnails");
@@ -302,6 +310,8 @@ public class SettingsDialog extends javax.swing.JDialog {
             this.public_folder_panel.setVisible(this.upload_public_folder_checkbox.isSelected());
 
             clipboardspy_checkbox.setSelected(monitor_clipboard);
+
+            always_reload_mega_folders_checkbox.setSelected(always_reload_mega_folders);
 
             String default_download_dir = DBTools.selectSettingValue("default_down_dir");
 
@@ -822,6 +832,7 @@ public class SettingsDialog extends javax.swing.JDialog {
         megacrypter_reverse_port_spinner = new javax.swing.JSpinner();
         down_dir_label = new javax.swing.JLabel();
         clipboardspy_checkbox = new javax.swing.JCheckBox();
+        always_reload_mega_folders_checkbox = new javax.swing.JCheckBox();
         smart_proxy_settings = new javax.swing.JPanel();
         jLabel5 = new javax.swing.JLabel();
         jLabel3 = new javax.swing.JLabel();
@@ -1063,6 +1074,9 @@ public class SettingsDialog extends javax.swing.JDialog {
         clipboardspy_checkbox.setFont(new java.awt.Font("Dialog", 1, 18)); // NOI18N
         clipboardspy_checkbox.setText("Monitor clipboard looking for new links");
 
+        always_reload_mega_folders_checkbox.setFont(new java.awt.Font("Dialog", 1, 18)); // NOI18N
+        always_reload_mega_folders_checkbox.setText("Always reload MEGA folders instead of using cached folder data");
+
         smart_proxy_settings.setEnabled(false);
 
         jLabel5.setFont(new java.awt.Font("Noto Sans", 1, 16)); // NOI18N
@@ -1257,6 +1271,7 @@ public class SettingsDialog extends javax.swing.JDialog {
                             .addComponent(verify_file_down_checkbox)
                             .addComponent(limit_download_speed_checkbox)
                             .addComponent(clipboardspy_checkbox)
+                            .addComponent(always_reload_mega_folders_checkbox)
                             .addGroup(downloads_panelLayout.createSequentialGroup()
                                 .addGap(21, 21, 21)
                                 .addGroup(downloads_panelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -1305,6 +1320,8 @@ public class SettingsDialog extends javax.swing.JDialog {
                 .addComponent(rec_download_slots_label)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(clipboardspy_checkbox)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(always_reload_mega_folders_checkbox)
                 .addGap(10, 10, 10)
                 .addComponent(limit_download_speed_checkbox)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
@@ -2160,6 +2177,7 @@ public class SettingsDialog extends javax.swing.JDialog {
             settings.put("run_command", run_command_checkbox.isSelected() ? "yes" : "no");
             settings.put("run_command_path", run_command_textbox.getText());
             settings.put("clipboardspy", clipboardspy_checkbox.isSelected() ? "yes" : "no");
+            settings.put("always_reload_mega_folders", always_reload_mega_folders_checkbox.isSelected() ? "yes" : "no");
             settings.put("thumbnails", thumbnail_checkbox.isSelected() ? "yes" : "no");
             settings.put("upload_log", upload_log_checkbox.isSelected() ? "yes" : "no");
             settings.put("force_smart_proxy", force_smart_proxy_checkbox.isSelected() ? "yes" : "no");
@@ -3308,6 +3326,7 @@ public class SettingsDialog extends javax.swing.JDialog {
     private javax.swing.JButton add_mega_account_button;
     private javax.swing.JPanel advanced_panel;
     private javax.swing.JScrollPane advanced_scrollpane;
+    private javax.swing.JCheckBox always_reload_mega_folders_checkbox;
     private javax.swing.JSpinner auto_refresh_proxy_time_spinner;
     private javax.swing.JSpinner bad_proxy_time_spinner;
     private javax.swing.JButton cancel_button;


### PR DESCRIPTION
Introduce a user-controllable setting for bypassing cached MEGA folder node reads. When enabled, folder cache existence checks report no cache and folder node lookups skip reading cached JSON, which suppresses the cached-version prompt and forces a fresh MEGA lookup.

The fresh lookup still updates the temporary folder cache, so disabling the setting later restores the existing cached-folder behavior without discarding refreshed cache data.

Expose the setting in the Downloads settings tab as: "Always reload MEGA folders instead of using cached folder data"